### PR TITLE
Allow using of a key value in a simple object section.

### DIFF
--- a/repository/Mustache-Core.package/MustacheWriteVisitor.class/instance/visitSection..st
+++ b/repository/Mustache-Core.package/MustacheWriteVisitor.class/instance/visitSection..st
@@ -5,5 +5,9 @@ visitSection: aSection
 	value := aSection valueInContext: context.
 	[ value isClosure 
 		ifTrue: [ self renderSection: aSection withBlock: value ]
-		ifFalse: [ self renderSection: aSection withObject: value ]]
+		ifFalse: [ 
+			value isDictionary 
+			ifTrue: [ self renderSection: aSection withObject: value ]
+			ifFalse: [self renderSection: aSection withObject: context] 
+			]]
 			ensure: [ context := oldContext ]


### PR DESCRIPTION
This allows use of a simple key -> value object in a context within a section. With this it's very easy to include conditional pieces of text based on whether a key is set in the context.

For example

```smalltalk
tmpl := MustacheTemplate on: ' {{#key}} Only include {{ key }} if it''s set {{/key}}'.
context := { 'key' -> 'test'  } asDictionary .
tmpl value: context.
```