### PR TITLE
Dependency fix

### DIFF
--- a/repository/BaselineOfMustache/BaselineOfMustache.class.st
+++ b/repository/BaselineOfMustache/BaselineOfMustache.class.st
@@ -1,29 +1,24 @@
 Class {
 	#name : #BaselineOfMustache,
 	#superclass : #BaselineOf,
-	#category : 'BaselineOfMustache'
+	#category : #BaselineOfMustache
 }
 
 { #category : #baselines }
 BaselineOfMustache >> baseline: spec [
+
 	<baseline>
-
-	spec for: #'common' do: [
-		spec project: 'JSON' with: [
-				spec
-					className: #ConfigurationOfJSON;
-					versionString: #'stable';
-					loads: #('default' );
-					repository: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/' ].
-		spec 
+	spec for: #common do: [ 
+		spec
+			baseline: 'JSON'
+			with: [ spec repository: 'github://sebastianconcept/JSON:v1.0.1' ].
+		spec
 			package: 'Mustache-Core';
-			package: 'Mustache-Tests' with: [
-				spec requires: #('Mustache-Core' ). ];
-			package: #'Mustache-Cli' with: [
-				spec requires: #('JSON' ). ].
-		spec 
-			group: 'Core' with: #('Mustache-Core' );
-			group: 'Tests' with: #('Mustache-Tests' );
-			group: 'default' with: #('Core' 'Tests' #'Mustache-Cli' ). ].
-
+			package: 'Mustache-Tests'
+			with: [ spec requires: #( 'Mustache-Core' ) ];
+			package: #'Mustache-Cli' with: [ spec requires: #( 'JSON' ) ].
+		spec
+			group: 'Core' with: #( 'Mustache-Core' );
+			group: 'Tests' with: #( 'Mustache-Tests' );
+			group: 'default' with: #( 'Core' 'Tests' #'Mustache-Cli' ) ]
 ]

--- a/repository/BaselineOfMustache/BaselineOfMustache.class.st
+++ b/repository/BaselineOfMustache/BaselineOfMustache.class.st
@@ -1,3 +1,6 @@
+"
+I help loading Mustache
+"
 Class {
 	#name : #BaselineOfMustache,
 	#superclass : #BaselineOf,
@@ -11,7 +14,7 @@ BaselineOfMustache >> baseline: spec [
 	spec for: #common do: [ 
 		spec
 			baseline: 'JSON'
-			with: [ spec repository: 'github://sebastianconcept/JSON:v1.0.1' ].
+			with: [ spec repository: 'github://sebastianconcept/JSON:v1.0.2' ].
 		spec
 			package: 'Mustache-Core';
 			package: 'Mustache-Tests'


### PR DESCRIPTION
Thanks for making Mustache @noha it's very handy and I would like to pull it as dependency for a project. 

Yet I've noticed it conflicts with JSON coming from deprecated SmalltalkHub.

This PR here is my suggestion to remove the reference to that dependency on smalltalkhub as I'm happy to maintain https://github.com/sebastianconcept/JSON which I need as dependency in a couple of other projects.

Main change is:
```
baseline: 'JSON' with: [ spec repository: 'github://sebastianconcept/JSON:v1.0.2' ].
```

Instead of:
```
repository: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/' ].
```
The rest is autoformatter