### PR TITLE
Replaced Json by STONJSON, removing dependency on Json

### DIFF
--- a/repository/BaselineOfMustache/BaselineOfMustache.class.st
+++ b/repository/BaselineOfMustache/BaselineOfMustache.class.st
@@ -9,18 +9,11 @@ BaselineOfMustache >> baseline: spec [
 	<baseline>
 
 	spec for: #'common' do: [
-		spec project: 'JSON' with: [
-				spec
-					className: #ConfigurationOfJSON;
-					versionString: #'stable';
-					loads: #('default' );
-					repository: 'http://smalltalkhub.com/mc/PharoExtras/JSON/main/' ].
 		spec 
 			package: 'Mustache-Core';
 			package: 'Mustache-Tests' with: [
 				spec requires: #('Mustache-Core' ). ];
-			package: #'Mustache-Cli' with: [
-				spec requires: #('JSON' ). ].
+			package: #'Mustache-Cli'.
 		spec 
 			group: 'Core' with: #('Mustache-Core' );
 			group: 'Tests' with: #('Mustache-Tests' );

--- a/repository/Mustache-Cli/MustacheCommandLineHandler.class.st
+++ b/repository/Mustache-Cli/MustacheCommandLineHandler.class.st
@@ -10,20 +10,21 @@ Options:
 	[--baseDirectory] 		a directory where files can be found
 "
 Class {
-	#name : #MustacheCommandLineHandler,
-	#superclass : #CommandLineHandler,
+	#name : 'MustacheCommandLineHandler',
+	#superclass : 'CommandLineHandler',
 	#instVars : [
 		'baseDirectory'
 	],
-	#category : 'Mustache-Cli'
+	#category : 'Mustache-Cli',
+	#package : 'Mustache-Cli'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : 'as yet unclassified' }
 MustacheCommandLineHandler class >> commandName [
 	^'mustache'
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 MustacheCommandLineHandler >> activate [
 	| result template json partials |
 	self activateHelp
@@ -35,41 +36,41 @@ MustacheCommandLineHandler >> activate [
 	template := (self baseDirectory resolve: self templateOption) contents.
 	partials := self partialsToDictionary: self partialsOption.
 	result := (MustacheTemplate on: template)
-		value: (Json readFrom: json readStream)
+		value: (STONJSON fromStream: json readStream)
 		partials: partials.
 	self stdout nextPutAll: result.
 	self stdout flush.
 	self exitSuccess
 ]
 
-{ #category : #activation }
+{ #category : 'activation' }
 MustacheCommandLineHandler >> baseDirectory [
 	^ baseDirectory ifNil: [ FileSystem workingDirectory ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MustacheCommandLineHandler >> errorFileNotFound: aString [
 	self help.
 	self exitFailure: 'The file ', aString, ' was not found'.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MustacheCommandLineHandler >> errorNeed: aString [
 	self help.
 	self exitFailure: 'You need to define ', aString.
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MustacheCommandLineHandler >> jsonDataOption [
 	^ self optionAt: 'data' ifAbsent: [ self errorNeed: 'data' ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MustacheCommandLineHandler >> partialsOption [
 	^ self optionAt: 'partials' ifAbsent: [ '' ].
 ]
 
-{ #category : #private }
+{ #category : 'private' }
 MustacheCommandLineHandler >> partialsToDictionary: aString [
 	| fileNames file partials name |
 	self flag: #TODO.
@@ -87,7 +88,7 @@ MustacheCommandLineHandler >> partialsToDictionary: aString [
 	^ partials 
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 MustacheCommandLineHandler >> templateOption [
 	^ self optionAt: 'template' ifAbsent: [ self errorNeed: 'template' ]
 ]

--- a/repository/Mustache-Cli/package.st
+++ b/repository/Mustache-Cli/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Mustache-Cli' }
+Package { #name : 'Mustache-Cli' }


### PR DESCRIPTION
Fixes https://github.com/noha/mustache/issues/11 by replacing usage of `Json` class by `STONJSON`, removing dependency on unmaintained JSON project on smalltalkhub that cannot be loaded into Pharo 12.

This is an alternative to https://github.com/noha/mustache/pull/12 that proposes moving the Json project, while this one removes the dependency on it altogether.

Note that this `MustacheCommandLineHandler` class has no tests, so I am not completely sure this change does not have any side effects.