### PR TITLE
Use special string method for mustache when it turns an object into a…

### DIFF
--- a/repository/Mustache-Core/MustacheWriteVisitor.class.st
+++ b/repository/Mustache-Core/MustacheWriteVisitor.class.st
@@ -27,7 +27,7 @@ MustacheWriteVisitor >> context: anObject [
 
 { #category : 'private' }
 MustacheWriteVisitor >> convertToString: anObject [ 
-	^ anObject asString
+	^ anObject mustacheString
 ]
 
 { #category : 'initialize-release' }

--- a/repository/Mustache-Core/Object.extension.st
+++ b/repository/Mustache-Core/Object.extension.st
@@ -32,3 +32,8 @@ Object >> mustacheLookupComplex: aString [
 		ifTrue: [ self mustacheDefaultWhenLookupFails ]
 		ifFalse: [ (self mustacheLookup: firstPart) mustacheLookup: stream upToEnd ]
 ]
+
+{ #category : '*mustache-core' }
+Object >> mustacheString [ 
+	^ self asString 
+]


### PR DESCRIPTION
… string. By implementing mustacheString every object can overwrite this without having to fiddle with asString