### PR TITLE
Adding comments + extend default error

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'repository'
+}

--- a/repository/.properties
+++ b/repository/.properties
@@ -1,0 +1,3 @@
+{
+	#format : #filetree
+}

--- a/repository/Mustache-Core.package/Object.extension/instance/mustacheDefaultWhenLookupFails..st
+++ b/repository/Mustache-Core.package/Object.extension/instance/mustacheDefaultWhenLookupFails..st
@@ -1,0 +1,4 @@
+*mustache-core
+mustacheDefaultWhenLookupFails: failingPartString
+
+	^ nil

--- a/repository/Mustache-Core.package/Object.extension/instance/mustacheLookup..st
+++ b/repository/Mustache-Core.package/Object.extension/instance/mustacheLookup..st
@@ -1,5 +1,9 @@
 *mustache-core
 mustacheLookup: aString
+	"The lookup supports navigation between objects using messages expressed by $. 
+	
+	For example {{{ site.configuration }}} means that the template accesses the value returned by the message configuration sent to the result of the message site."
+	
 	(aString = '.') ifTrue: [ ^ self ].
 	^ (self respondsTo: aString asSymbol) 
 		ifTrue: [ self perform: aString asSymbol ]

--- a/repository/Mustache-Core.package/Object.extension/instance/mustacheLookupComplex..st
+++ b/repository/Mustache-Core.package/Object.extension/instance/mustacheLookupComplex..st
@@ -1,8 +1,9 @@
 *mustache-core
 mustacheLookupComplex: aString
+	
 	| stream firstPart |
 	stream := aString readStream.
 	firstPart := stream upTo: $. .
 	^ stream atEnd
-		ifTrue: [ self mustacheDefaultWhenLookupFails ]
+		ifTrue: [ self mustacheDefaultWhenLookupFails: aString  ]
 		ifFalse: [ (self mustacheLookup: firstPart) mustacheLookup: stream upToEnd ]

--- a/repository/Mustache-Core.package/monticello.meta/categories.st
+++ b/repository/Mustache-Core.package/monticello.meta/categories.st
@@ -1,1 +1,1 @@
-SystemOrganization addCategory: #'Mustache-Core'!
+self packageOrganizer ensurePackage: #'Mustache-Core' withTags: #()!


### PR DESCRIPTION
Hi norbert

- Adding comments + extend default error
Make sure that when a path element is not defined the error is passed the element name  so that we can build advanced error handing (similar to DNU)

Adding a parameter to the default lets me introduce an extension mechanism.
This way the user can add variable in a configuration file and the template can access them without having to define the method explicitly. 


